### PR TITLE
Fix sticky nav issue covering top of page (mobile-responsive); re-add ternary statements for career profile

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -11,6 +11,7 @@ import Footer from './Footer.jsx';
 import Home from './Home.jsx';
 import createBrowserHistory from 'history/createBrowserHistory';
 import CareerProfileContainer from './CareerProfileContainer.jsx';
+import MediaQuery from 'react-responsive';
 
 const newHistory = createBrowserHistory();
 
@@ -55,17 +56,32 @@ class App extends React.Component {
       <Router history={newHistory} >
         <div>
           <NavBar />
-          <div style={{ marginTop: '56px' }}>
-            <Switch>
-              <Route exact path="/" component={Home} />
-              <Route exact path="/careers" render={props => {
-                return <Careers router={props} careers={this.props.careers} industries={this.props.industries}/>;
-              }} />
-              <Route path="/careers/:id" render={props => {
-                return <CareerProfileContainer router={props} />;
-              }} />
-            </Switch>
-          </div>
+          <MediaQuery query="(min-width: 600px)">
+            <div style={{ marginTop: '64px' }}>
+              <Switch>
+                <Route exact path="/" component={Home} />
+                <Route exact path="/careers" render={props => {
+                  return <Careers router={props} careers={this.props.careers} industries={this.props.industries}/>;
+                }} />
+                <Route path="/careers/:id" render={props => {
+                  return <CareerProfileContainer router={props} />;
+                }} />
+              </Switch>
+            </div>
+          </MediaQuery>
+          <MediaQuery query="(max-width: 599px)">
+            <div style={{ marginTop: '56px' }}>
+              <Switch>
+                <Route exact path="/" component={Home} />
+                <Route exact path="/careers" render={props => {
+                  return <Careers router={props} careers={this.props.careers} industries={this.props.industries} />;
+                }} />
+                <Route path="/careers/:id" render={props => {
+                  return <CareerProfileContainer router={props} />;
+                }} />
+              </Switch>
+            </div>
+          </MediaQuery>
           <Footer />
         </div>
       </Router>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -55,7 +55,7 @@ class App extends React.Component {
       <Router history={newHistory} >
         <div>
           <NavBar />
-          <div>
+          <div style={{ marginTop: '56px' }}>
             <Switch>
               <Route exact path="/" component={Home} />
               <Route exact path="/careers" render={props => {

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -72,7 +72,7 @@ class NavBar extends React.Component {
     const { anchorEl } = this.state;
     return (
       <div className={classes.root}>
-        <AppBar position="static">
+        <AppBar position="fixed">
           <Toolbar className={classes.tools}>
             <IconButton 
             className={classes.menuButton} 


### PR DESCRIPTION
Fixed sticky nav issue by adding a margin-top to the parent div surrounding the Switch/Routes and used MediaQuery components to account for responsiveness.

I had to re-add the ternary statements because the app broke again :( I'd rather just keep it there since it has a fail-safe. 