### PR TITLE
Polish styling of career list, training list, and favorites lists

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -38,6 +38,9 @@ class App extends React.Component {
       uri: '/graphql'
     }).bind(this);
     this.sortBy = 'Highest salary';
+    this.state = {
+      showSignOutButton: false
+    }
   }
 
   componentDidMount() {

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -295,7 +295,7 @@ const mapStateToProps = state => {
   return {
     careers: state.careers.careers,
     industries: state.industries.industries,
-    user: state.user.user,
+    user: state.user,
     favorites: state.favorites.favorites
   };
 };

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -37,55 +37,6 @@ class App extends React.Component {
       uri: '/graphql'
     }).bind(this);
     this.sortBy = 'Highest salary';
-    this.sampleFavoritesData = {
-      favorites: [
-        {
-          'career_id': null,
-          'service_id': '14',
-          'user_id': '45'
-        },
-        {
-          'career_id': '1',
-          'service_id': null,
-          'user_id': '45'
-        },
-        {
-          'career_id': '5',
-          'service_id': null,
-          'user_id': '45'
-        },
-        {
-          'career_id': '6',
-          'service_id': null,
-          'user_id': '45'
-        },
-        {
-          'career_id': '3',
-          'service_id': null,
-          'user_id': '45'
-        },
-        {
-          'career_id': '2',
-          'service_id': null,
-          'user_id': '45'
-        },
-        {
-          'career_id': null,
-          'service_id': '13',
-          'user_id': '45'
-        },
-        {
-          'career_id': null,
-          'service_id': '12',
-          'user_id': '45'
-        },
-        {
-          'career_id': null,
-          'service_id': '11',
-          'user_id': '45'
-        }
-      ]
-    };
   }
 
   componentDidMount() {
@@ -278,11 +229,11 @@ class App extends React.Component {
                     careers={this.props.careers}
                     industries={this.props.industries}
                     filterCareers={this.filterCareers}
-                    favorites={this.sampleFavoritesData.favorites}
+                    favorites={this.props.favorites}
                   />;
                 }} />
                 <Route path="/careers/:id" render={props => {
-                  return <CareerProfileContainer router={props} favorites={this.sampleFavoritesData.favorites} />;
+                  return <CareerProfileContainer router={props} favorites={this.props.favorites} />;
                 }} />
                 <Route path='/services/:id' render={props => {
                   return <ServiceListContainer router={props} />;
@@ -305,7 +256,7 @@ const mapStateToProps = state => {
     careers: state.careers.careers,
     industries: state.industries.industries,
     user: state.user,
-    favorites: state.favorites
+    favorites: state.favorites.favorites
   };
 };
 

--- a/client/src/components/Career.jsx
+++ b/client/src/components/Career.jsx
@@ -28,18 +28,21 @@ const styles = theme => ({
   },
 
   image: {
-    height: '110px'
+    maxHeight: '110px',
+    width: '110px'
   },
 
   learnButton: {
     backgroundColor: '#4469FF',
-    top: '8px'
+    top: '8px',
+    borderRadius: '3px'
   },
 
   trainingButton: {
     backgroundColor: 'transparent',
     color: 'grey',
-    top: '8px'
+    top: '8px',
+    borderRadius: '3px'
   }
 });
 class Career extends React.Component {
@@ -67,8 +70,8 @@ class Career extends React.Component {
                 </Typography>
               </Grid>
               <Grid item xs={4}>
-                <CardMedia 
-                  image={this.props.career.card_image_url || '#'}
+                <img 
+                  src={this.props.career.card_image_url || '#'}
                   title="Dummy Title"
                   className={classes.image}
                 />

--- a/client/src/components/Career.jsx
+++ b/client/src/components/Career.jsx
@@ -7,56 +7,98 @@ import Button from '@material-ui/core/Button';
 import CardMedia from '@material-ui/core/CardMedia';
 import { Link } from 'react-router-dom';
 import HeartContainer from './heartComponents/HeartContainer.jsx';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  grid: {
+    maxWidth: '97%', 
+    margin: '0 auto 8px'
+  },
+
+  card: {
+    borderRadius: '3px'
+  },
+
+  cardContent: {
+    paddingBottom: '5px!important'
+  },
+
+  text: {
+    paddingRight: '6px'
+  },
+
+  image: {
+    height: '110px'
+  },
+
+  learnButton: {
+    backgroundColor: '#4469FF',
+    top: '8px'
+  },
+
+  trainingButton: {
+    backgroundColor: 'transparent',
+    color: 'grey',
+    top: '8px'
+  }
+});
 class Career extends React.Component {
   constructor(props) {
     super(props);
   }
 
   render() {
-    const style = {
-      height: '20%'
-    };
+    const { classes } = this.props;
+
     return (
-      <Grid item xs={12}>
-        <Card>
-          <CardContent>
+      <Grid item xs={12} className={classes.grid}>
+        <Card className={classes.card}>
+          <CardContent className={classes.cardContent}>
             <Grid container>
-              <Grid item xs={9}>
-                <Typography color="textSecondary">
+              <Grid item xs={8} className={classes.text}>
+                <Typography color="textSecondary" gutterBottom>
                   {this.props.career.industry_name}
                 </Typography>
-                <Typography variant="headline">
+                <Typography variant="headline" paragraph>
                   {this.props.career.name}
                 </Typography>
-                <Typography color="textSecondary">
+                <Typography color="textSecondary" paragraph>
                   {this.props.career.card_pro}
-                  <br />
-                  <br />
-                  Salary: {this.props.career.annual_salary}
-                  <br/>
-                  Training length: {this.props.career.training_length}
                 </Typography>
               </Grid>
-              <Grid item xs={3}>
+              <Grid item xs={4}>
                 <CardMedia 
                   image={this.props.career.card_image_url || '#'}
                   title="Dummy Title"
-                  style={style}
+                  className={classes.image}
                 />
               </Grid>
             </Grid>
-            <Grid container spacing={8}>
+            <Grid>
+              <Grid item xs={12}>
+                <Typography color="textSecondary" paragraph>
+                  Salary: {this.props.career.annual_salary}
+                  <br />
+                  Training length: {this.props.career.training_length}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid container>
               <Grid item xs={5}>
-                <Button variant="contained" color="primary" style={{backgroundColor: '#4469FF'}} component={Link} to={`/careers/${this.props.career.id}`}>
+                <Button 
+                  variant="contained" 
+                  color="primary" 
+                  className={classes.learnButton} 
+                  component={Link} 
+                  to={`/careers/${this.props.career.id}`}>
                   LEARN MORE
                 </Button>
               </Grid>
               <Grid item xs={5}>
-                <Button style={{
-                  backgroundColor: 'transparent',
-                  color: 'grey'
-                }} component={Link} to={`/services/${this.props.career.id}`}>
+                <Button 
+                  className={classes.trainingButton} 
+                  component={Link} 
+                  to={`/services/${this.props.career.id}`}>
                   FIND TRAINING
                 </Button>
               </Grid>
@@ -75,4 +117,4 @@ class Career extends React.Component {
   }
 } 
 
-export default Career;
+export default withStyles(styles)(Career);

--- a/client/src/components/Career.jsx
+++ b/client/src/components/Career.jsx
@@ -48,7 +48,7 @@ class Career extends React.Component {
             </Grid>
             <Grid container spacing={8}>
               <Grid item xs={5}>
-                <Button variant="contained" color="primary" style={{backgroundColor: '2979ff'}} component={Link} to={`/careers/${this.props.career.id}`}>
+                <Button variant="contained" color="primary" style={{backgroundColor: '#4469FF'}} component={Link} to={`/careers/${this.props.career.id}`}>
                   LEARN MORE
                 </Button>
               </Grid>

--- a/client/src/components/Careers.jsx
+++ b/client/src/components/Careers.jsx
@@ -6,8 +6,17 @@ import { store } from '../store/index';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getPageTitle } from '../actions/action';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  background: {
+    backgroundColor: '#CFCFCE'
+  },
 
+  grid: {
+    marginTop: '8px'
+  }
+});
 
 class Careers extends React.Component {
   constructor(props) {
@@ -21,13 +30,14 @@ class Careers extends React.Component {
   }
 
   render() {
+    const { classes } = this.props;
     return (
-      <div>
+      <div className={classes.background}>
         <FilterandSort 
           industries={this.props.industries}
           filterCareers={this.props.filterCareers}
         />
-        <Grid container spacing={8}>
+        <Grid container className={classes.grid}>
           {this.props.careers.map((career, index) => {
             return <Career key={career.id || index} career={career} favorites={this.props.favorites}/>;
           })}
@@ -47,4 +57,4 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators({ getPageTitle}, dispatch);
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Careers);
+export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Careers));

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -173,7 +173,9 @@ class NavBar extends React.Component {
               {this.props.showSignOutButton ? 
                       (<MenuItem onClick={this.handleSignOut}>
                       <Link to="/home">
-                        
+                        <ListItemIcon>
+                          <img src='https://s3.amazonaws.com/key-up-assets/Sign-out-gray.png' className={classes.logoutIcon}/>
+                        </ListItemIcon>
                         <ListItemText style={{ float: 'right' }} inset primary="Sign Out">
                         </ListItemText>
                       </Link>
@@ -253,6 +255,13 @@ NavBar.styles = {
     marginBottom: '1em',
     textDecoration: 'none',
     borderRadius: '2px'
+  },
+
+  logoutIcon: {
+    height: '24px',
+    width: '24px',
+    marginLeft: '3px',
+    marginRight: '13px'
   }
 
 };

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -188,7 +188,7 @@ NavBar.styles = {
     left: 0,
     borderRadius: 0,
     display: 'flex',
-    backgroundColor: '2979ff'
+    backgroundColor: '#4469FF'
   },
   home: {
     padding: '0'

--- a/client/src/components/Service.jsx
+++ b/client/src/components/Service.jsx
@@ -6,18 +6,48 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import CardMedia from '@material-ui/core/CardMedia';
 import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  grid: {
+    maxWidth: '97%',
+    margin: '0 auto 8px'
+  },
+
+  card: {
+    borderRadius: '3px'
+  },
+
+  text: {
+    paddingRight: '6px'
+  },
+
+  image: {
+    maxHeight: '110px',
+    width: '110px'
+  },
+
+  imageGrid: {
+    flexGrow: '1',
+    marginTop: '10px'
+  },
+
+  learnButton: {
+    backgroundColor: '#4469FF',
+    top: '8px',
+    borderRadius: '3px'
+  }
+});
 
 const Service = props => {
-  const style = {
-    height: '20%'
-  };
+  const { classes } = props;
+
   return (
-    <Grid item xs={12}>
-      <Card>
+    <Grid item xs={12} className={classes.grid}>
+      <Card className={classes.card}>
         <CardContent>
           <Grid container>
-            <Grid item xs={9}>
+            <Grid item xs={8} className={classes.text}>
               <Typography color="textSecondary">
                 {props.service.career_name}
               </Typography>
@@ -29,20 +59,25 @@ const Service = props => {
                 Training length: {props.service.card_length}
                 <br/>
                 Tuition range: {props.service.card_tuition}
-                <br/>
-                Locations: {props.service.card_location}
-                <br/>
               </Typography>
             </Grid>
-            <Grid item xs={3}>
-              <CardMedia
-                image={props.service.logo_url || '#'}
+            <Grid item xs={4} className={classes.imageGrid}>
+              <img
+                src={props.service.logo_url || '#'}
                 title="Dummy Title"
-                style={style}
+                className={classes.image}
               />
             </Grid>
           </Grid>
-          <Button variant="contained" color="primary" style={{backgroundColor: '#4469FF', marginTop: '10px'}} component={Link} to={`/service/${props.service.id}`}>
+          <Typography color="textSecondary">
+            Locations: {props.service.card_location}
+          </Typography>
+          <Button 
+            variant="contained" 
+            color="primary" 
+            className={classes.learnButton} 
+            component={Link} 
+            to={`/service/${props.service.id}`}>
             LEARN MORE
           </Button>
         </CardContent>
@@ -51,4 +86,4 @@ const Service = props => {
   );
 }
 
-export default Service;
+export default withStyles(styles)(Service);

--- a/client/src/components/Service.jsx
+++ b/client/src/components/Service.jsx
@@ -42,7 +42,7 @@ const Service = props => {
               />
             </Grid>
           </Grid>
-          <Button variant="contained" color="primary" style={{backgroundColor: '2979ff', marginTop: '10px'}} component={Link} to={`/service/${props.service.id}`}>
+          <Button variant="contained" color="primary" style={{backgroundColor: '#4469FF', marginTop: '10px'}} component={Link} to={`/service/${props.service.id}`}>
             LEARN MORE
           </Button>
         </CardContent>

--- a/client/src/components/Services.jsx
+++ b/client/src/components/Services.jsx
@@ -6,7 +6,17 @@ import { store } from '../store/index';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getPageTitle } from '../actions/action';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  background: {
+    backgroundColor: '#CFCFCE'
+  },
+
+  grid: {
+    marginTop: '8px'
+  }
+});
 class Services extends React.Component {
   constructor(props) {
     super(props);
@@ -17,10 +27,11 @@ class Services extends React.Component {
   }
 
   render() {
+    const { classes } = this.props;
     return (
-      <div>
+      <div className={classes.background}>
         <FilterAndSort services={this.props.services} careerID={this.props.careerID}/>
-        <Grid container spacing={8}>
+        <Grid container className={classes.grid}>
           {this.props.services.map((service, index) => {
             return <Service key={service.id || index} service={service}/>;
           })}
@@ -40,4 +51,4 @@ const mapDispatchToProps = dispatch => {
   return bindActionCreators({ getPageTitle}, dispatch);
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Services);
+export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Services));

--- a/client/src/components/SignUpForm.jsx
+++ b/client/src/components/SignUpForm.jsx
@@ -23,7 +23,7 @@ const styles = theme => ({
     maxWidth: '350px'
   },
   buttonStyle: {
-    backgroundColor: '#2979ff',
+    backgroundColor: '##4469FF',
     color: 'white',
     borderRadius: 0,
     marginTop: '2em'

--- a/client/src/components/careerProfileComponents/Trainings.jsx
+++ b/client/src/components/careerProfileComponents/Trainings.jsx
@@ -16,7 +16,7 @@ const styles = theme => ({
 
   button: {
     margin: '0px auto 10px',
-    backgroundColor: '2979ff'
+    backgroundColor: '#4469FF'
   }
 });
 

--- a/client/src/components/favoritesComponents/FavoriteCareers.jsx
+++ b/client/src/components/favoritesComponents/FavoriteCareers.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import Career from '../Career.jsx';
 import Grid from '@material-ui/core/Grid';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  grid: {
+    marginTop: '8px'
+  }
+});
 class FavoriteCareers extends React.Component {
   constructor(props) {
     super(props);
   }
 
   render() {
+    const { classes } = this.props;
     return (
-      <Grid container spacing={8}>
+      <Grid container className={classes.grid}>
         {this.props.careers.map((career, index) => {
           return <Career key={career.id || index} career={career} favorites={this.props.favorites}/>;
         })}
@@ -18,4 +25,4 @@ class FavoriteCareers extends React.Component {
   }
 }
 
-export default FavoriteCareers;
+export default withStyles(styles)(FavoriteCareers);

--- a/client/src/components/favoritesComponents/FavoriteTrainings.jsx
+++ b/client/src/components/favoritesComponents/FavoriteTrainings.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Service from '../Service.jsx';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  grid: {
+    marginTop: '8px'
+  }
+});
 class FavoriteTrainings extends React.Component {
   constructor(props) {
     super(props);
   }
 
   render() {
+    const { classes } = this.props;
+
     return (
-      <Grid container spacing={8}>
+      <Grid container className={classes.grid}>
         {this.props.services.map((service, index) => {
           return <Service key={service.id || index} service={service} favorites={this.props.favorites}/>;
         })}
@@ -18,4 +26,4 @@ class FavoriteTrainings extends React.Component {
   }
 }
 
-export default FavoriteTrainings;
+export default withStyles(styles)(FavoriteTrainings);

--- a/client/src/components/favoritesComponents/Favorites.jsx
+++ b/client/src/components/favoritesComponents/Favorites.jsx
@@ -11,8 +11,8 @@ import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 
 const styles = theme => ({
-  paper: {
-    height: '100%'
+  background: {
+    backgroundColor: '#CFCFCE'
   },
 
   tabs: {
@@ -36,15 +36,17 @@ const styles = theme => ({
 
 function NoFaves(props) {
   return (
-    <div style={{ padding: '30px 15px' }}>
-      <Typography variant='body1' paragraph>No favorites yet?</Typography>
-      <Typography variant='body1' paragraph>
-        <Link to='/careers' 
-          style={{
-            color: '#4469FF',
-            textDecoration: 'none'
-          }}>Browser Careers and Training</Link> to pick out some likely-looking {props.type}.
+    <div>
+      <Paper style={{ padding: '30px 15px', borderRadius: '0' }}>
+        <Typography variant='body1' paragraph>No favorites yet?</Typography>
+        <Typography variant='body1' paragraph>
+          <Link to='/careers'
+            style={{
+              color: '#4469FF',
+              textDecoration: 'none'
+            }}>Browser Careers and Training</Link> to pick out some likely-looking {props.type}.
       </Typography>
+      </Paper>
     </div>
   )
 }
@@ -116,31 +118,29 @@ class Favorites extends React.Component {
     }
 
     return (
-      <div>
-        <Paper className={classes.paper}>
-          <Tabs
-            value={this.state.value}
-            onChange={this.handleChange}
+      <div className={classes.background}>
+        <Tabs
+          value={this.state.value}
+          onChange={this.handleChange}
+          classes={{
+            indicator: classes.tabsIndicator
+          }}
+          className={classes.tabs}
+          centered
+        >
+          <Tab label="Favorite Careers"
             classes={{
-              indicator: classes.tabsIndicator
+              root: classes.tabRoot,
+              selected: classes.tabSelected
+            }} />
+          <Tab label="Favorite Training" 
+            classes={{
+              root: classes.tabRoot,
+              selected: classes.tabSelected
             }}
-            className={classes.tabs}
-            centered
-          >
-            <Tab label="Favorite Careers"
-              classes={{
-                root: classes.tabRoot,
-                selected: classes.tabSelected
-              }} />
-            <Tab label="Favorite Training" 
-              classes={{
-                root: classes.tabRoot,
-                selected: classes.tabSelected
-              }}
-            />
-          </Tabs>
-          {info}
-        </Paper>
+          />
+        </Tabs>
+        {info}
       </div>
     )
   }

--- a/client/src/components/favoritesComponents/Favorites.jsx
+++ b/client/src/components/favoritesComponents/Favorites.jsx
@@ -67,7 +67,7 @@ class Favorites extends React.Component {
     let careers = [];
     let trainings = [];
     //parsing the different types of favorites
-    if (this.props.favorites.length > 0) {
+    if (this.props.favorites && this.props.favorites.length > 0) {
       for (let fave of this.props.favorites) {
         if (fave.career_id !== null) {
           careers.push(fave.career_id);
@@ -103,7 +103,7 @@ class Favorites extends React.Component {
     //for rendering different information based on whether or not a user has favorites
     //nested conditional statements need to be done this way for easier readability than 
     //ternary statements
-    if (this.props.favorites[0].id === '' || this.props.favorites === undefined) {
+    if (this.props.favorites === undefined || this.props.favorites[0].id === '') {
       if (this.state.value === 0) {
         info = <NoFaves type='careers' />
       } else if (this.state.value === 1) {

--- a/client/src/components/favoritesComponents/Favorites.jsx
+++ b/client/src/components/favoritesComponents/Favorites.jsx
@@ -7,11 +7,16 @@ import FavoriteTrainings from './FavoriteTrainings.jsx';
 import { createApolloFetch } from 'apollo-fetch';
 import { getCareerFave, getTrainingFave } from '../graphql/graphql';
 import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import { Link } from 'react-router-dom';
 
 const styles = theme => ({
+  paper: {
+    height: '100%'
+  },
+
   tabs: {
-    backgroundColor: '#3651C5',
-    height: '3.5em'
+    backgroundColor: '#3651C5'
   },
 
   tabsIndicator: {
@@ -28,6 +33,21 @@ const styles = theme => ({
 
   tabSelected: {}
 });
+
+function NoFaves(props) {
+  return (
+    <div style={{ padding: '30px 15px' }}>
+      <Typography variant='body1' paragraph>No favorites yet?</Typography>
+      <Typography variant='body1' paragraph>
+        <Link to='/careers' 
+          style={{
+            color: '#4469FF',
+            textDecoration: 'none'
+          }}>Browser Careers and Training</Link> to pick out some likely-looking {props.type}.
+      </Typography>
+    </div>
+  )
+}
 class Favorites extends React.Component {
   constructor(props) {
     super(props);
@@ -76,10 +96,28 @@ class Favorites extends React.Component {
 
   render() {
     const { classes } = this.props;
-    // div with tabs - background color #3651C5
+    let info;
+
+    //for rendering different information based on whether or not a user has favorites
+    //nested conditional statements need to be done this way for easier readability than 
+    //ternary statements
+    if (this.props.favorites[0].id === '' || this.props.favorites === undefined) {
+      if (this.state.value === 0) {
+        info = <NoFaves type='careers' />
+      } else if (this.state.value === 1) {
+        info = <NoFaves type='training services' />
+      }
+    } else {
+      if (this.state.value === 0) {
+        info = <FavoriteCareers careers={this.state.careerFaves} favorites={this.props.favorites} />
+      } else if (this.state.value === 1) {
+        info = <FavoriteTrainings services={this.state.trainingFaves} favorites={this.props.favorites} />
+      }
+    }
+
     return (
       <div>
-        <Paper>
+        <Paper className={classes.paper}>
           <Tabs
             value={this.state.value}
             onChange={this.handleChange}
@@ -103,8 +141,7 @@ class Favorites extends React.Component {
               }}
             />
           </Tabs>
-          {this.state.value === 0 && <FavoriteCareers careers={this.state.careerFaves} favorites={this.props.favorites}/>}
-          {this.state.value === 1 && <FavoriteTrainings services={this.state.trainingFaves} favorites={this.props.favorites}/>}
+          {info}
         </Paper>
       </div>
     )

--- a/client/src/components/favoritesComponents/Favorites.jsx
+++ b/client/src/components/favoritesComponents/Favorites.jsx
@@ -121,8 +121,6 @@ class Favorites extends React.Component {
           <Tabs
             value={this.state.value}
             onChange={this.handleChange}
-            // indicatorColor="primary"
-            textColor="primary"
             classes={{
               indicator: classes.tabsIndicator
             }}

--- a/client/src/components/favoritesComponents/Favorites.jsx
+++ b/client/src/components/favoritesComponents/Favorites.jsx
@@ -6,7 +6,28 @@ import FavoriteCareers from './FavoriteCareers.jsx';
 import FavoriteTrainings from './FavoriteTrainings.jsx';
 import { createApolloFetch } from 'apollo-fetch';
 import { getCareerFave, getTrainingFave } from '../graphql/graphql';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = theme => ({
+  tabs: {
+    backgroundColor: '#3651C5',
+    height: '3.5em'
+  },
+
+  tabsIndicator: {
+    backgroundColor: '#02ED96'
+  },
+
+  tabRoot: {
+    color: '#EDEDEE',
+    padding: '10px',
+    '&$tabSelected': {
+      color: '#02ED96'
+    }
+  },
+
+  tabSelected: {}
+});
 class Favorites extends React.Component {
   constructor(props) {
     super(props);
@@ -54,6 +75,7 @@ class Favorites extends React.Component {
   };
 
   render() {
+    const { classes } = this.props;
     // div with tabs - background color #3651C5
     return (
       <div>
@@ -61,12 +83,25 @@ class Favorites extends React.Component {
           <Tabs
             value={this.state.value}
             onChange={this.handleChange}
-            indicatorColor="primary"
+            // indicatorColor="primary"
             textColor="primary"
+            classes={{
+              indicator: classes.tabsIndicator
+            }}
+            className={classes.tabs}
             centered
           >
-            <Tab label="Favorite Careers" />
-            <Tab label="Favorite Training" />
+            <Tab label="Favorite Careers"
+              classes={{
+                root: classes.tabRoot,
+                selected: classes.tabSelected
+              }} />
+            <Tab label="Favorite Training" 
+              classes={{
+                root: classes.tabRoot,
+                selected: classes.tabSelected
+              }}
+            />
           </Tabs>
           {this.state.value === 0 && <FavoriteCareers careers={this.state.careerFaves} favorites={this.props.favorites}/>}
           {this.state.value === 1 && <FavoriteTrainings services={this.state.trainingFaves} favorites={this.props.favorites}/>}
@@ -76,4 +111,4 @@ class Favorites extends React.Component {
   }
 }
 
-export default Favorites;
+export default withStyles(styles)(Favorites);

--- a/client/src/components/heartComponents/HeartContainer.jsx
+++ b/client/src/components/heartComponents/HeartContainer.jsx
@@ -6,20 +6,12 @@ import Typography from '@material-ui/core/Typography';
 
 const styles = theme => ({
   icon: {
-    position: 'relative',
-    top: '-4px',
-    left: '10px',
-    color: '#88888A',
-    textAlign: 'right',
-    flexDirection: 'column'
+    right: '8px',
+    color: '#88888A'
   },
   favoriteSelected: {
-    position: 'relative',
-    top: '-4px',
-    left: '10px',
-    color: '#7A94F4',
-    textAlign: 'right',
-    flexDirection: 'column'
+    right: '8px',
+    color: '#7A94F4'
   },
   buttonStyle: {
     flexDirection: 'column'

--- a/client/src/components/homePageComponents/FormHomePage.jsx
+++ b/client/src/components/homePageComponents/FormHomePage.jsx
@@ -28,7 +28,7 @@ const styles = theme => ({
     width: '95%'
   },
   buttonStyle: {
-    backgroundColor: '2979ff',
+    backgroundColor: '#4469FF',
     borderRadius: 0,
     marginTop: '1em'
   }

--- a/client/src/components/loginComponents/loginForm.jsx
+++ b/client/src/components/loginComponents/loginForm.jsx
@@ -13,7 +13,7 @@ const styles = theme => ({
     width: '90vw'
   },
   buttonStyle: {
-    backgroundColor: '2979ff',
+    backgroundColor: '#4469FF',
     color: 'white',
     borderRadius: 0,
     marginTop: '5em',

--- a/client/src/components/socialShareComponents/SendTextDialog.jsx
+++ b/client/src/components/socialShareComponents/SendTextDialog.jsx
@@ -53,7 +53,7 @@ class SendTextDialog extends React.Component {
               Cancel
             </Button>
             <a href={this.state.textLink} style={{ textDecoration: 'none' }}>
-              <Button color="primary" autoFocus style={{ backgroundColor: '2979ff', color: 'EDEDEE' }}>
+              <Button color="primary" autoFocus style={{ backgroundColor: '#4469FF', color: 'EDEDEE' }}>
                 Send Text
               </Button>
             </a>

--- a/client/src/reducers/favoritesReducers.js
+++ b/client/src/reducers/favoritesReducers.js
@@ -2,22 +2,9 @@ let defaultState = {
   favorites: [
     {
       id: '',
-      career: [{
-        name: '',
-        industry_name: '',
-        card_pro: '',
-        card_image_url: '',
-        annual_salary: '',
-        training_length: ''
-      }],
-      training_service: [{
-        career_name: '',
-        name: '',
-        logo_url: '',
-        card_length: '',
-        card_tuition: '',
-        card_location: ''
-      }]
+      career_id: '',
+      service_id: '',
+      user_id: ''
     }
   ]
 };


### PR DESCRIPTION
Other polishes:
- corrected nav bar color (and anything identical to it in the app)
- add logout icon to nav bar

Additionally, fixed bugs involving mapping user redux state to props (it only works for me when set to state.user not state.user.user - I get undefined no matter what if I use the latter).

Notes while testing:

1. User state did not persist upon refresh (session ID is still there so the backend is working correctly but the front end isn't)
2. When signing out, the session ID was not destroyed (it still was there in the Application tab of dev tools)